### PR TITLE
Updates base and CLI Docker images to Node 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ You can use the image with:
 This will download and install the [Hasura CLI](https://hasura.io/docs/2.0/hasura-cli/overview/).
 
 - `robmellett/hasura-cli`
+
+## Docker
+
+You can build docker images locally by running the following.
+
+```
+docker build -t robmellett/<name-of-container>:latest .
+```

--- a/src/base/Dockerfile
+++ b/src/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM phusion/baseimage:jammy-1.0.1
 LABEL Rob Mellett <dev@robmellett.com>
 
-ARG NODE_VERSION=20
+ARG NODE_VERSION=24
 
 # Ensure UTF-8
 RUN locale-gen en_US.UTF-8

--- a/src/contentful-cli/Dockerfile
+++ b/src/contentful-cli/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 LABEL Rob Mellett <dev@robmellett.com>
 
-ARG NODE_VERSION=20
+ARG NODE_VERSION=24
 
 RUN apt-get update \
     && apt-get install -y gpg curl ca-certificates zip unzip git \


### PR DESCRIPTION
Upgrades the Node.js version from 20 to 24 in the base and CLI Dockerfiles to stay current with the latest Node.js releases and benefit from improved performance and security.