### PR TITLE
Updates base Docker image to phusion/baseimage:noble

### DIFF
--- a/src/base/Dockerfile
+++ b/src/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:jammy-1.0.1
+FROM phusion/baseimage:noble
 LABEL Rob Mellett <dev@robmellett.com>
 
 ARG NODE_VERSION=24


### PR DESCRIPTION
Updates the base Docker image to use the latest `phusion/baseimage:noble` tag to ensure the environment stays current and secure.

This change lays the groundwork for improved stability and maintenance by relying on an updated and possibly better-supported base image.

No new PHP or npm packages are installed or updated.

No new environment variables are added.