### PR TITLE
Adds Laravel installer to PHP 8.5 CLI container

### DIFF
--- a/src/php85-cli/Dockerfile
+++ b/src/php85-cli/Dockerfile
@@ -22,6 +22,8 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
     && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
     && rm composer-setup.php composer-installer.sig
 
+RUN composer global require laravel/installer
+
 WORKDIR /app
 
 CMD ["php", "-a"]


### PR DESCRIPTION
Adds the Laravel installer globally via Composer in the PHP 8.5 CLI container to streamline Laravel project creation and development.

This change improves the developer experience by pre-installing the Laravel installer, eliminating the need for manual installation after container setup.

No new environment variables or npm packages are introduced.

Includes:
- Global installation of the Laravel installer Composer package