### PR TITLE
Sets COMPOSER_HOME and updates PATH for global Composer dependencies

### DIFF
--- a/src/php85-cli/Dockerfile
+++ b/src/php85-cli/Dockerfile
@@ -7,11 +7,13 @@ ENV LANG=C.UTF-8
 
 # @See https://github.com/composer/composer/issues/9150
 ENV COMPOSER_CACHE_READ_ONLY=1
+ENV COMPOSER_HOME=/usr/local/share/composer
 
 # Install some additional packages and the Laravel
 # installer uses them when creating a new project
 RUN apt-get update \
     && apt-get install -y curl ca-certificates zip unzip git libzip-dev libsqlite3-dev \
+    && docker-php-ext-install zip \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -23,6 +25,8 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
     && rm composer-setup.php composer-installer.sig
 
 RUN composer global require laravel/installer
+
+ENV PATH="${COMPOSER_HOME}/vendor/bin:${PATH}"
 
 WORKDIR /app
 


### PR DESCRIPTION
Updates the PHP 8.5 CLI Dockerfile to explicitly set the `COMPOSER_HOME` environment variable, ensuring that globally installed Composer packages such as the Laravel installer are placed in a consistent directory.

This change also extends the `PATH` to include the Composer vendor binaries, making global commands (like the Laravel installer) accessible system-wide in the container without additional configuration.

Additionally, it installs the `zip` PHP extension to support Composer and Laravel dependencies that require it.

These improvements streamline the setup and usage of Composer global packages in the container, enhancing developer experience and preventing potential path or permission issues.

No npm packages or `.env` variables are added or updated as part of this change.