### PR TITLE
Add Laravel installation instructions for php-cli container

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,32 @@ docker run --rm -it \
     robmellett/php-85-cli:latest composer install
 ```
 
+### Installing Laravel
+
+The image bundles `laravel/installer`, so you can scaffold a new project without installing anything on your host:
+
+```shell
+docker run --rm -it \
+    --user "$(id -u):$(id -g)" \
+    -v "$(pwd)":/app \
+    robmellett/php-85-cli:latest \
+    laravel new my-app
+```
+
+This creates a `my-app/` directory inside your current working directory. The interactive installer will prompt for starter kit preferences, testing framework, and other options.
+
+Alternatively, install via Composer directly:
+
+```shell
+docker run --rm -it \
+    --user "$(id -u):$(id -g)" \
+    -v "$(pwd)":/app \
+    robmellett/php-85-cli:latest \
+    composer create-project laravel/laravel my-app
+```
+
+Once the project is created, `cd` into it and use the [shell aliases](#shell-aliases) below to run `php` and `composer` commands as if they were installed natively.
+
 ### Shell aliases
 
 To make the container feel like a locally-installed PHP toolchain, add a wrapper function and aliases to your `~/.zshrc` (or `~/.bashrc`):


### PR DESCRIPTION
## Summary

- Adds an "Installing Laravel" subsection to the PHP CLI section of the README
- Documents how to scaffold a new Laravel project using `laravel new` via the `robmellett/php-85-cli` image (which already bundles `laravel/installer`)
- Also shows the `composer create-project` alternative for users who prefer it
- Links to the shell aliases section so readers know how to run follow-up commands

## Test plan

- [ ] Verify `docker run ... robmellett/php-85-cli:latest laravel new my-app` creates a project in the current directory
- [ ] Verify `docker run ... robmellett/php-85-cli:latest composer create-project laravel/laravel my-app` works as an alternative
- [ ] Confirm file ownership is correct when `--user "$(id -u):$(id -g)"` is passed

https://claude.ai/code/session_01ENXhg8r8jdiNbFZ1ZnDPDf

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENXhg8r8jdiNbFZ1ZnDPDf)_