### PR TITLE
[Weekly] Laravel Sail Docker Image Update v1.66.0

### DIFF
--- a/src/php82/Dockerfile
+++ b/src/php82/Dockerfile
@@ -57,6 +57,8 @@ RUN apt-get update && apt-get upgrade -y \
         php8.2-imagick \
         php8.2-xdebug \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
+    && COMPOSER_HOME=/usr/local/share/composer composer global require cpx/cpx:^1.0 \
+    && ln -s /usr/local/share/composer/vendor/bin/cpx /usr/local/bin/cpx \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \

--- a/src/php83/Dockerfile
+++ b/src/php83/Dockerfile
@@ -57,6 +57,8 @@ RUN apt-get update && apt-get upgrade -y \
         php8.3-imagick \
         php8.3-xdebug \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
+    && COMPOSER_HOME=/usr/local/share/composer composer global require cpx/cpx:^2.0 \
+    && ln -s /usr/local/share/composer/vendor/bin/cpx /usr/local/bin/cpx \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \

--- a/src/php84/Dockerfile
+++ b/src/php84/Dockerfile
@@ -57,6 +57,8 @@ RUN apt-get update && apt-get upgrade -y \
         php8.4-imagick \
         php8.4-xdebug \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
+    && COMPOSER_HOME=/usr/local/share/composer composer global require cpx/cpx:^2.0 \
+    && ln -s /usr/local/share/composer/vendor/bin/cpx /usr/local/bin/cpx \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \

--- a/src/php85/Dockerfile
+++ b/src/php85/Dockerfile
@@ -57,6 +57,8 @@ RUN apt-get update && apt-get upgrade -y \
         php8.5-imagick \
         php8.5-xdebug \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
+    && COMPOSER_HOME=/usr/local/share/composer composer global require cpx/cpx:^2.0 \
+    && ln -s /usr/local/share/composer/vendor/bin/cpx /usr/local/bin/cpx \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \


### PR DESCRIPTION
Pulled from [laravel/sail v1.66.0](https://github.com/laravel/sail/releases/tag/v1.66.0):

* Add CPX command support by @wilsenhc in https://github.com/laravel/sail/pull/895